### PR TITLE
Use Django 1.9+ location for postgresql backend

### DIFF
--- a/django_postgres_readonly/base.py
+++ b/django_postgres_readonly/base.py
@@ -1,4 +1,4 @@
-from django.db.backends.postgresql_psycopg2 import base
+from django.db.backends.postgresql import base
 
 
 class DatabaseWrapper(base.DatabaseWrapper):

--- a/django_postgres_readonly/base.py
+++ b/django_postgres_readonly/base.py
@@ -1,4 +1,8 @@
-from django.db.backends.postgresql import base
+try:
+    # Django 1.9+
+    from django.db.backends.postgresql import base
+except ImportError:
+    from django.db.backends.postgresql_psycopg2 import base
 
 
 class DatabaseWrapper(base.DatabaseWrapper):


### PR DESCRIPTION
This was renamed in [Django Ticket #25175](https://code.djangoproject.com/ticket/25175) and there's an ongoing discussion about removing the old name.